### PR TITLE
BIP-84 extended key serialization, address derivation and related tests

### DIFF
--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -61,8 +61,8 @@ fn hdwallet() -> Result<(), HDWError> {
     mpub:  {}\n
     address (m/0/0):   {}
     ", mnemonic.phrase.join(" "),
-       hdw.mpriv_key().serialize(),
-       hdw.mpub_key().serialize(),
+       hdw.mpriv_key().serialize_legacy(),
+       hdw.mpub_key().serialize_legacy(),
        Address::from_pub_key(
            &hdw.mpriv_key()
            .get_xchild(ChildOptions::Normal(0))?
@@ -75,7 +75,7 @@ fn hdwallet() -> Result<(), HDWError> {
     let xprv = hdw.get_xprv_key_at("m/44'/0'/0'/0/0").unwrap();
     println!("Key pair at 'm/44'/0'/0'/0':");
     println!("{}", xprv.get_prv().export_as_wif(true, false));
-    println!("{}", xprv.get_xpub().serialize());
+    println!("{}", xprv.get_xpub().serialize_legacy());
     println!("{:?}", hdw.get_addresses("m/44'/0'/0'/0/0", 10).unwrap());
     
 

--- a/src/encoding/bs58check.rs
+++ b/src/encoding/bs58check.rs
@@ -14,6 +14,9 @@ pub enum VersionPrefix {
     //BIP32
     Xprv,
     Xpub,
+    //BIP84
+    Zprv,
+    Zpub,
     None
 }
 
@@ -41,6 +44,8 @@ pub fn check_encode(prefix: VersionPrefix, data: &[u8]) -> String {
         VersionPrefix::TestNetPrivateKeyWIF => vec![0xef],
         VersionPrefix::Xprv => vec![0x04, 0x88, 0xAD, 0xE4],
         VersionPrefix::Xpub => vec![0x04, 0x88, 0xB2, 0x1E],
+        VersionPrefix::Zprv => vec![0x04, 0xb2, 0x43, 0x0c],
+        VersionPrefix::Zpub => vec![0x04, 0xb2, 0x47, 0x46],
         VersionPrefix::None => vec![]
     };
 

--- a/src/hdwallet/ckd.rs
+++ b/src/hdwallet/ckd.rs
@@ -202,9 +202,9 @@ mod tests {
 
         //Get the first child extended private and public key of the master key.
         //Calculate the child extended public key twice  through the master xpub and child xprv
-        let derived_m0 = hdw.mpriv_key().get_xchild(ChildOptions::Normal(0)).unwrap().serialize();
-        let derived_M0_fromxprv = hdw.mpriv_key().get_xchild(ChildOptions::Normal(0)).unwrap().get_xpub().serialize();
-        let derived_M0_fromxpub = hdw.mpub_key().get_xchild(ChildOptions::Normal(0)).unwrap().serialize();
+        let derived_m0 = hdw.mpriv_key().get_xchild(ChildOptions::Normal(0)).unwrap().serialize_legacy();
+        let derived_M0_fromxprv = hdw.mpriv_key().get_xchild(ChildOptions::Normal(0)).unwrap().get_xpub().serialize_legacy();
+        let derived_M0_fromxpub = hdw.mpub_key().get_xchild(ChildOptions::Normal(0)).unwrap().serialize_legacy();
 
         //Test is derived values are equal to expected values and if derived xpubs are both identical
         assert_eq!(derived_m0, EXPECTED_m0.to_string());
@@ -219,12 +219,12 @@ mod tests {
 
         //Calculate the hardened children of the master keys.
         //Deriving the corresponding xpub of a hardened xprv is not possible. So pattern match the error.
-        let derived_m0h = hdw.mpriv_key().get_xchild(ChildOptions::Hardened(0)).unwrap().serialize();
+        let derived_m0h = hdw.mpriv_key().get_xchild(ChildOptions::Hardened(0)).unwrap().serialize_legacy();
         let derived_M0h_fromxpub = match hdw.mpub_key().get_xchild(ChildOptions::Hardened(0)) {
             Ok(_) => true,
             Err(_) => false
         }; 
-        let derived_M0h_fromxprv = hdw.mpriv_key().get_xchild(ChildOptions::Hardened(0)).unwrap().get_xpub().serialize();
+        let derived_M0h_fromxprv = hdw.mpriv_key().get_xchild(ChildOptions::Hardened(0)).unwrap().get_xpub().serialize_legacy();
 
         //Test is derived values are equal to expected values and if hardened xpub deriveration failed
         assert_eq!(derived_m0h, EXPECTED_m0h);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,13 +15,11 @@
             for providing clear reference code to work against, especially with bip32.
 
     Todo:
-        - Create HDWallet from a Xprv string (use the provided key as master)
-        - Generate array of addresses given a deriveration path and count
-            Implement tests and function to create xprv and xpub by count
         - Create P2SH addresses using multisig.
            - Method to take in m of n option and the required keys -> MultiSig redeem Script
            - Hash the script to make the address
-        - Create Bech32 addresses
+        
+        - Serialization of BIP-49 (P2SH nested P2WPKH keys using ypriv/ypub prefix)
 */
 
 //Outward facing modules


### PR DESCRIPTION
Implemented functionality to serialize extended keys created from a mnemonic phrase with `zprv` and `zpub` prefixes to indicate that the keys are to generate SegWit P2WPKH addresses.

eg:
```
let mnemonic: Mnemonic = Mnemonic::from_phrase("<my mnemonic>".to_string(), Language::English, "").unwrap();
let hdw = HDWallet::new(mnemonic).unwrap();

let account = hdw.get_xprv_key_at("m/84'/0'/0'/0/0").unwrap();
println!("{}", Address::p2wpkh(&account.get_pub()).unwrap());
```