### PR TITLE
Multisig script construction 

### DIFF
--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -6,6 +6,7 @@ fn main() {
     //println!("{:?}", verify_mnemonic_phrase());
     //println!("{:?}", verify_bad_phrase());
     //hdwallet().unwrap()
+    multisig_address();
 }
 
 fn print_vals() {
@@ -80,4 +81,20 @@ fn hdwallet() -> Result<(), HDWError> {
     
 
     Ok(())
+}
+
+fn multisig_address() {
+    let keys: Vec<PrivKey> = vec![
+        PrivKey::new_rand(),
+        PrivKey::new_rand(),
+        PrivKey::new_rand()
+    ];
+
+    let m = 2;
+    let n = 3;
+
+    let script = Script::multisig(m, n, &keys).unwrap();
+    let address = Address::p2wsh(&script).unwrap();
+
+    println!("{}", address);
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -5,7 +5,7 @@ use crate:: {
         bs58check as bs58check,
         bech32 as bech32
     },
-    script::RedeemScript
+    script::Script
 };
 
 pub struct Address;
@@ -27,7 +27,7 @@ impl Address {
     /**
         Creates a P2SH address from a redeem script
     */
-    pub fn from_script(script: &RedeemScript) -> String {
+    pub fn from_script(script: &Script) -> String {
         bs58check::check_encode(bs58check::VersionPrefix::P2ScriptAddress, &script.hash())
     }
 
@@ -48,7 +48,7 @@ impl Address {
     /**
         Creates a P2SH address for the test net
     */
-    pub fn testnet_script_address(script: &RedeemScript) -> String {
+    pub fn testnet_script_address(script: &Script) -> String {
         bs58check::check_encode(bs58check::VersionPrefix::TestnetP2SHAddress, &script.hash())
     }
 
@@ -71,7 +71,7 @@ impl Address {
     /**
         Create mainnet P2WSH addresses from a redeem script
     */
-    pub fn p2wsh(script: &RedeemScript) -> Result<String, bech32::Bech32Err> {
+    pub fn p2wsh(script: &Script) -> Result<String, bech32::Bech32Err> {
         let hash = hash::sha256(script.script.clone());
         Ok(bech32::encode_to_address(&hash, "mainnet")?)
     }
@@ -79,7 +79,7 @@ impl Address {
     /**
         Create mainnet P2WSH addresses from a redeem script
     */
-    pub fn testnet_p2wsh(script: &RedeemScript) -> Result<String, bech32::Bech32Err> {
+    pub fn testnet_p2wsh(script: &Script) -> Result<String, bech32::Bech32Err> {
         let hash = hash::sha256(script.script.clone());
         Ok(bech32::encode_to_address(&hash, "testnet")?)
     }
@@ -111,7 +111,7 @@ mod tests {
     use crate::{
         key::PrivKey,
         util::decode_02x,
-        script::RedeemScript
+        script::Script
     };
 
     const TEST_PUB_KEY_HEX: &str = "0204664c60ceabd82967055ccbd0f56a1585dfbd42032656efa501c463b16fbdfe";
@@ -183,14 +183,14 @@ mod tests {
     #[test]
     fn p2sh_address_tests() {
         //Test data test
-        let script: RedeemScript = RedeemScript::new(vec![0x6a, 0x29, 0x05, 0x20, 0x03]);
+        let script: Script = Script::new(vec![0x6a, 0x29, 0x05, 0x20, 0x03]);
         let derived_address = Address::from_script(&script);
         let expected_address = "33SjjXog5Tqm3kCYNGCQBH46gc48a4SUXn".to_string();
         assert!(derived_address == expected_address);
 
         //Random mainnet tests
         for i in 0..5 {
-            let script: RedeemScript = RedeemScript::new(vec![i; 5]);
+            let script: Script = Script::new(vec![i; 5]);
             let address = Address::from_script(&script);
             match address.chars().nth(0) {
                 Some('3') => assert!(true),
@@ -200,7 +200,7 @@ mod tests {
 
         //Random testnet tests
         for i in 0..5 {
-            let script: RedeemScript = RedeemScript::new(vec![i; 5]);
+            let script: Script = Script::new(vec![i; 5]);
             let address = Address::testnet_script_address(&script);
             match address.chars().nth(0) {
                 Some('2') => assert!(true),
@@ -226,7 +226,7 @@ mod tests {
 
     #[test]
     fn p2wsh_address_tests() {
-        let redeem_script: RedeemScript = RedeemScript::new(vec![0x6a, 0x29, 0x05, 0x20, 0x03]);
+        let redeem_script: Script = Script::new(vec![0x6a, 0x29, 0x05, 0x20, 0x03]);
         let derived_mainnet_address = Address::p2wsh(&redeem_script).unwrap();
         let expected_mainnet_address = "bc1q4sr2gyed4ww8zm0t9ktn47qxlu2nhl5ejkf6fjzfttnsjvxdkqjqe7yhq9".to_string();
         let derived_testnet_address = Address::testnet_p2wsh(&redeem_script).unwrap();

--- a/src/encoding/bech32.rs
+++ b/src/encoding/bech32.rs
@@ -3,14 +3,6 @@
 */
 use bitcoin_bech32::{WitnessProgram, u5};
 use bitcoin_bech32::constants::Network;
-use crate::{
-    key::{
-        PubKey
-    },
-    script::{
-        RedeemScript
-    }
-};
 
 #[derive(Debug)]
 pub enum Bech32Err {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -35,6 +35,6 @@ pub use crate::{
         try_into
     },
 
-    script::RedeemScript
+    script::Script
 
 };

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -4,18 +4,25 @@
 
 use crate::{
     hash,
-    address::Address
+    address::Address,
+    key::{
+        PrivKey,
+        Key
+    }
 };
 
-pub struct RedeemScript {
+pub struct Script {
     pub script: Vec<u8>
 }
 
+#[derive(Debug)]
 pub enum ScriptErr {
-    BadNetwork()
+    BadNetwork(),
+    KeyCountDoesNotMatch(),
+    MaxKeyCountExceeded()
 }
 
-impl RedeemScript {
+impl Script {
     /**
         Create a new instance of self
     */
@@ -41,5 +48,26 @@ impl RedeemScript {
             "mainnet" => Ok(Address::from_script(self)),
             _ => Err(ScriptErr::BadNetwork())
         }
+    }
+
+    /**
+        Creates the redeem script for a m-of-n multisig wallet
+        BIP-11
+    */
+    pub fn multisig(m: u8, n: u8, keys: &Vec<PrivKey>) -> Result<Self, ScriptErr> {
+        if n != keys.len() as u8 { return Err(ScriptErr::KeyCountDoesNotMatch()) }
+        if m > 15 { return Err(ScriptErr::MaxKeyCountExceeded()) }
+        
+        let mut script: Vec<u8> = vec![m + 80]; //m value as opcode
+
+        for i in 0..keys.len() {
+            script.push(0x20);
+            script.append(&mut keys[i].as_bytes::<32>().to_vec());
+        }
+
+        script.push(n + 80); //n value as opcode
+        script.push(0xAE);   //op_checkmultisig
+
+        Ok(Script::new(script))
     }
 }


### PR DESCRIPTION
Added functionality to create M-of-N multi signature scripts (BIP-11).

Once the script is created, the script can be encoded as an address by using the` Address::from_script()` for legacy P2SH 3addresses or `Address::p2wsh()` for Segwit bc1 addresses.